### PR TITLE
Idempotent config change

### DIFF
--- a/component_accumulo.yaml
+++ b/component_accumulo.yaml
@@ -1,5 +1,4 @@
 ---
 - hosts: localhost
-  run_once: true
   roles:
     - name: accumulo

--- a/component_accumulo.yaml
+++ b/component_accumulo.yaml
@@ -1,12 +1,5 @@
-- hosts: ACCUMULO_MASTER
+---
+- hosts: localhost
+  run_once: true
   roles:
-    - name: ambari_config
-      ambari_component_name: accumulo-site
-      ambari_component_props:
-        monitor.ssl.keyStore: "{{ certs_dir }}/{{ certs_jks_file }}"
-        monitor.ssl.keyStoreType: JKS
-        monitor.ssl.keyStorePassword: "{{ certs_jks_store_password }}"
-        monitor.ssl.trustStore: "{{ certs_dir }}/{{ certs_jks_file }}"
-        monitor.ssl.trustStorePassword: "{{ certs_jks_store_password }}"
-        monitor.ssl.trustStoreType: JKS
-        rpc.sasl.qop: auth-conf
+    - name: accumulo

--- a/component_accumulo.yaml
+++ b/component_accumulo.yaml
@@ -1,4 +1,4 @@
 ---
-- hosts: localhost
+- hosts: ACCUMULO_MASTER
   roles:
     - name: accumulo

--- a/component_kafka.yaml
+++ b/component_kafka.yaml
@@ -1,5 +1,4 @@
 ---
 - hosts: localhost
-  run_once: true
   roles:
     - name: kafka

--- a/component_kafka.yaml
+++ b/component_kafka.yaml
@@ -1,13 +1,5 @@
-- hosts: KAFKA_BROKER
+---
+- hosts: localhost
+  run_once: true
   roles:
-    - name: ambari_config
-      ambari_component_name: kafka-broker
-      ambari_component_props:
-        listeners: PLAINTEXT://localhost:6667,SSL://localhost:6666
-        ssl.key.password: "{{ certs_jks_key_password }}"
-        ssl.keystore.location: "{{ certs_dir }}/{{ certs_jks_file }}"
-        ssl.keystore.password: "{{ certs_jks_store_password }}"
-        ssl.keystore.type: JKS
-        ssl.truststore.location: "{{ certs_dir }}/{{ certs_jks_file }}"
-        ssl.truststore.password: "{{ certs_jks_store_password }}"
-        ssl.truststore.type: JKS
+    - name: kafka

--- a/component_kafka.yaml
+++ b/component_kafka.yaml
@@ -1,4 +1,4 @@
 ---
-- hosts: localhost
+- hosts: KAFKA_BROKER
   roles:
     - name: kafka

--- a/component_nifi.yaml
+++ b/component_nifi.yaml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  run_once: true
+  pre_tasks:
+    - name: gathering cluster side configs as facts
+      run_once: true
+      delegate_to: "{{ ambari_host }}"
+      ambari_component_facts:
+        protocol: http
+        port: 8080
+        username: "{{ ambari_user }}"
+        password: "{{ ambari_password }}"
+        cluster_name: "{{ ambari_cluster_name }}"
+  roles:
+    - name: nifi

--- a/component_nifi.yaml
+++ b/component_nifi.yaml
@@ -1,4 +1,4 @@
 ---
-- hosts: localhost
+- hosts: NIFI_MASTER
   roles:
     - name: nifi

--- a/component_nifi.yaml
+++ b/component_nifi.yaml
@@ -1,5 +1,4 @@
 ---
 - hosts: localhost
-  run_once: true
   roles:
     - name: nifi

--- a/component_nifi.yaml
+++ b/component_nifi.yaml
@@ -1,15 +1,5 @@
 ---
 - hosts: localhost
   run_once: true
-  pre_tasks:
-    - name: gathering cluster side configs as facts
-      run_once: true
-      delegate_to: "{{ ambari_host }}"
-      ambari_component_facts:
-        protocol: http
-        port: 8080
-        username: "{{ ambari_user }}"
-        password: "{{ ambari_password }}"
-        cluster_name: "{{ ambari_cluster_name }}"
   roles:
     - name: nifi

--- a/library/ambari_cluster_config.py
+++ b/library/ambari_cluster_config.py
@@ -1,0 +1,368 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Documentation section
+DOCUMENTATION = '''
+---
+module: ambari_cluster_config
+version_added: "1.0"
+short_description: Capture or update Ambari cluster configurations
+  - Capture or update Ambari cluster configurations
+options:
+  protocol:
+    description:
+      The protocol for the ambari web server (http / https)
+  host:
+    description:
+      The hostname for the ambari web server
+     default:
+      localhost
+  port:
+    description:
+      The port for the ambari web server
+  context_path:
+    description:
+      In case Ambari has a proxy in front of it, context path is the additional path, which must be prepended to each Ambari call. It should include a prepended slash, but no trailing slash
+    required: no
+    default:
+      ''
+  username:
+    description:
+      The username for the ambari web server
+  password:
+    description:
+      The name of the cluster in web server
+    required: yes
+  cluster_name:
+    description:
+      The name of the cluster in ambari
+    required: yes
+  config_type:
+    description:
+      The configuration type for Ambari cluster configurations
+    required: yes
+  tag:
+    description:
+      The tag version for a configuration type in Ambari
+    required: no
+  ignore_secret:
+    description:
+      Whether to ignore the secrets as the configurations of Ambari secrets is not shown via api calls, Default is True
+    required: no
+  config_map:
+    description:
+      The map object for all configurations need to be checked and updated
+    required: yes
+'''
+
+EXAMPLES = '''
+# If you are aiming to provide a full file replacement / template replacement, please use the `lookup` plugin provided
+# in native ansible
+# example:
+  - name: Update a cluster configuration
+    ambari_cluster_config:
+        protocol: http
+        host: localhost
+        port: 8080
+        context_path: /ambari
+        username: admin
+        password: admin
+        cluster_name: my_cluster
+        config_type: admin-properties
+        ignore_secret: true
+        timeout_sec: 10
+        config_map:
+          db_root_user:
+            value: root
+          key_x2:
+            value: value_y2
+            regex: ^your_regex to fully replace
+          key_x3:
+            value: "{{lookup('template', './files/mytemplate.j2')}}"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import json
+import os
+
+try:
+    import requests
+except ImportError:
+    REQUESTS_FOUND = False
+else:
+    REQUESTS_FOUND = True
+
+try:
+    import yaml
+except ImportError:
+    YAML_FOUND = False
+else:
+    YAML_FOUND = True
+
+try:
+    import time
+except ImportError:
+    TIME_FOUND = False
+else:
+    TIME_FOUND = True
+
+try:
+    import re
+except ImportError:
+    REGEX_FOUND = False
+else:
+    REGEX_FOUND = True
+
+import traceback
+
+
+def main():
+    argument_spec = dict(
+        protocol=dict(type='str', default='http', required=False),
+        host=dict(type='str', default='localhost', required=False),
+        port=dict(type='int', default=None, required=True),
+        context_path=dict(type='str', default='', required=False),
+        username=dict(type='str', default=None, required=True),
+        password=dict(type='str', default=None, required=True, no_log=True),
+        cluster_name=dict(type='str', default=None, required=True),
+        config_type=dict(type='str', default=None, required=True),
+        config_tag=dict(type='str', default=None, required=False),
+        ignore_secret=dict(default=True, required=False,
+                           choices=[True, False]),
+        timeout_sec=dict(type='int', default=10, required=False),
+        config_map=dict(type='dict', default=None, required=True)
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec
+    )
+
+    if not REQUESTS_FOUND:
+        module.fail_json(
+            msg='requests library is required for this module')
+
+    if not YAML_FOUND:
+        module.fail_json(
+            msg='pyYaml library is required for this module')
+
+    if not TIME_FOUND:
+        module.fail_json(
+            msg='time library is required for this module')
+
+    if not REGEX_FOUND:
+        module.fail_json(
+            msg='regex(re) library is required for this module')
+
+    p = module.params
+
+    protocol = p.get('protocol')
+    host = p.get('host')
+    port = p.get('port')
+    context_path = p.get('context_path')
+    username = p.get('username')
+    password = p.get('password')
+    cluster_name = p.get('cluster_name')
+    config_type = p.get('config_type')
+    config_tag = p.get('config_tag')
+    config_map = p.get('config_map')
+    ignore_secret = p.get('ignore_secret')
+    connection_timeout = p.get('timeout_sec')
+
+    process_ambari_config(module, protocol, host, port, context_path, username, password,
+                          cluster_name, config_type, config_tag, config_map, ignore_secret, connection_timeout)
+
+
+def process_ambari_config(module, protocol, host, port, context_path, username, password, cluster_name, config_type,
+                          config_tag, config_map, ignore_secret, connection_timeout):
+    ambari_url = '{0}://{1}:{2}{3}'.format(protocol, host, port, context_path)
+
+    try:
+        # Get current effective version/tag if not specified
+        if config_tag is None:
+            config_index = get_cluster_config_index(
+                ambari_url, username, password, cluster_name, connection_timeout)
+            config_tag = config_index[config_type]["tag"]
+        # Get config using the effective tag
+        overall_cluster_config = get_cluster_config(
+            ambari_url, username, password, cluster_name, config_type, config_tag, connection_timeout)
+        cluster_config = overall_cluster_config['properties']
+
+        changed, has_secrets, result_map, updated_map = sync_config_map_with_cluster(cluster_config, config_map,
+                                                                                     ignore_secret)
+
+        if changed:
+            request = update_cluster_config(
+                ambari_url, username, password, cluster_name, config_type, result_map,
+                extract_properties_attributes(overall_cluster_config), connection_timeout)
+            module.exit_json(
+                changed=True, results=request.content, msg={'result': result_map, 'updates': updated_map})
+        else:
+            if has_secrets:
+                request = update_cluster_config(ambari_url, username, password, cluster_name,
+                                                config_type, result_map,
+                                                extract_properties_attributes(overall_cluster_config),
+                                                connection_timeout)
+                module.exit_json(
+                    changed=False, results=request.content, msg={'result': result_map, 'updates': updated_map})
+            else:
+                module.exit_json(changed=False, msg='No changes in config')
+    except requests.ConnectionError as e:
+        module.fail_json(
+            msg="Could not connect to Ambari client: " + str(e.message), stacktrace=traceback.format_exc())
+    except AssertionError as e:
+        module.fail_json(msg=e.message, stacktrace=traceback.format_exc())
+    except Exception as e:
+        module.fail_json(
+            msg="Ambari client exception occurred: " + str(e.message), stacktrace=traceback.format_exc())
+
+
+def sync_config_map_with_cluster(cluster_config, config_map, ignore_secret):
+    changed = False
+    has_secrets = False
+    result_map = {}
+    updated_map = {}
+    # Start iterate through the config with input
+    for key in cluster_config:
+        current_value = cluster_config[key]
+        if key in config_map:
+            desired_value = config_map[key].get('value')
+            if desired_value is not None and (
+                    current_value == desired_value or str(current_value).lower() == str(desired_value).lower()):
+                # if value matched, put it directly into the map
+                result_map[key] = current_value
+            else:
+                # Mismatched!
+                # Get the require-to-update value base on regex/non-regex
+                (actual_value, updated) = get_config_desired_value(
+                    cluster_config, key, desired_value, config_map[key].get('regex'))
+                # base on the regex sub, if not changed then change the change state to False
+                if ignore_secret and current_value.startswith('SECRET'):
+                    updated = False
+                    has_secrets = True
+                changed = changed or updated
+                result_map[key] = actual_value
+                if updated:
+                    if 'password' in key or 'pw' in key or 'token' in key:
+                        updated_map[key] = {'origin': hash_passwords(
+                            cluster_config[key]), 'changed_to': hash_passwords(actual_value)}
+                    else:
+                        updated_map[key] = {
+                            'origin': cluster_config[key], 'changed_to': actual_value}
+        else:
+            result_map[key] = current_value
+
+    # Loop through all config_map and make sure additional keys are put into the map as well
+    for key in config_map:
+        if key not in cluster_config:
+            changed = True
+            result_map[key] = config_map.get(key).get('value')
+            updated_map[key] = {
+                'origin': 'no such key', 'changed_to': config_map.get(key).get('value')
+            }
+
+    return changed, has_secrets, result_map, updated_map
+
+
+def hash_passwords(pw):
+    return '*' * len(pw)
+
+
+def get_config_desired_value(current_map, key, desired_value, regex):
+    if regex is None or regex == '':
+        # if not contains regex, straight return the desired_value
+        return desired_value, True
+    else:
+        # if contains regex, us re.sub to replace the regex pattern with desired_value
+        result = re.sub(regex, desired_value, current_map[key])
+        return result, result == current_map[key]
+
+
+def update_cluster_config(ambari_url, user, password, cluster_name, config_type, updated_map, properties_attributes,
+                          connection_timeout):
+    ts = time.time()
+    tag_ts = ts * 1000
+    payload = {
+        'type': config_type,
+        'tag': 'version{0}'.format('%d' % tag_ts),
+        'properties': updated_map,
+        'service_config_version_note': 'Ansible module syncing',
+    }
+    if properties_attributes is not None:
+        payload['properties_attributes'] = properties_attributes
+    put_body = {'Clusters': {'desired_config': []}}
+    put_body['Clusters']['desired_config'].append(payload)
+    put_list = []
+    put_list.append(put_body)
+    r = put(ambari_url, user, password,
+            '/api/v1/clusters/{0}'.format(cluster_name), json.dumps(put_list), connection_timeout)
+    try:
+        assert r.status_code == 200 or r.status_code == 201
+    except AssertionError as e:
+        e.message = 'Coud not update cluster with desired configuration: request code {0}, \
+                    request message {1}'.format(r.status_code, r.content)
+        raise
+    return r
+
+
+def extract_properties_attributes(overall_config):
+    try:
+        properties_attribute = overall_config['properties_attributes']
+        return properties_attribute
+    except KeyError:
+        properties_attribute = None
+        return properties_attribute
+
+
+def get_cluster_config_index(ambari_url, user, password, cluster_name, connection_timeout):
+    r = get(ambari_url, user, password,
+            '/api/v1/clusters/{0}?fields=Clusters/desired_configs'.format(cluster_name), connection_timeout)
+    try:
+        assert r.status_code == 200
+    except AssertionError as e:
+        e.message = 'Coud not get cluster desired configuration: request code {0}, \
+                    request message {1}'.format(r.status_code, r.content)
+        raise
+    clusters = json.loads(r.content)
+    return clusters['Clusters']['desired_configs']
+
+
+def get_cluster_config(ambari_url, user, password, cluster_name, config_type, config_tag, connection_timeout):
+    r = get(ambari_url, user, password,
+            '/api/v1/clusters/{0}/configurations?type={1}&tag={2}'.format(cluster_name, config_type, config_tag),
+            connection_timeout)
+    try:
+        assert r.status_code == 200
+    except AssertionError as e:
+        e.message = 'Coud not get cluster configuration: request code {0}, \
+                    request message {1}'.format(r.status_code, r.content)
+        raise
+    config = json.loads(r.content)
+    try:
+        assert config['items'][0]['properties'] is not None
+        return config['items'][0]
+    except KeyError as e:
+        e.message = 'Could not find the right properties key, request code {0}, \
+                     possiblly having a wrong tag, response content is: {1}'.format(r.status_code, r.content)
+        raise
+    except AssertionError as e:
+        e.message = 'Could not find the right properties key, request code {0}, \
+                     possiblly having a wrong tag, response content is: {1}'.format(r.status_code, r.content)
+        raise
+
+
+def get(ambari_url, user, password, path, connection_timeout):
+    headers = {'X-Requested-By': 'ambari'}
+    r = requests.get(ambari_url + path, auth=(user, password),
+                     headers=headers, timeout=connection_timeout)
+    return r
+
+
+def put(ambari_url, user, password, path, data, connection_timeout):
+    headers = {'X-Requested-By': 'ambari'}
+    r = requests.put(ambari_url + path, data=data,
+                     auth=(user, password), headers=headers, timeout=connection_timeout)
+    return r
+
+
+if __name__ == '__main__':
+    main()

--- a/main.yaml
+++ b/main.yaml
@@ -1,3 +1,4 @@
 - import_playbook: certs.yaml
-- import_playbook: component_accumulo.yaml
 - import_playbook: component_kafka.yaml
+- import_playbook: component_accumulo.yaml
+- import_playbook: component_nifi.yaml

--- a/main.yaml
+++ b/main.yaml
@@ -1,12 +1,12 @@
 ---
-- hosts: localhost
+- hosts: all
   tasks:
   - name: gathering cluster side configs as facts
     run_once: true
-    delegate_to: "{{ ambari_host }}"
     ambari_component_facts:
       protocol: http
       port: 8080
+      host: "{{ ambari_host }}"
       username: "{{ ambari_user }}"
       password: "{{ ambari_password }}"
       cluster_name: "{{ ambari_cluster_name }}"

--- a/main.yaml
+++ b/main.yaml
@@ -1,3 +1,16 @@
+---
+- hosts: localhost
+  tasks:
+  - name: gathering cluster side configs as facts
+    run_once: true
+    delegate_to: "{{ ambari_host }}"
+    ambari_component_facts:
+      protocol: http
+      port: 8080
+      username: "{{ ambari_user }}"
+      password: "{{ ambari_password }}"
+      cluster_name: "{{ ambari_cluster_name }}"
+
 - import_playbook: certs.yaml
 - import_playbook: component_kafka.yaml
 - import_playbook: component_accumulo.yaml

--- a/roles/accumulo/defaults/main.yaml
+++ b/roles/accumulo/defaults/main.yaml
@@ -1,0 +1,9 @@
+ambari_component_name: accumulo-site
+ambari_component_props:
+  monitor.ssl.keyStore: "{{ certs_dir }}/{{ certs_jks_file }}"
+  monitor.ssl.keyStoreType: JKS
+  monitor.ssl.keyStorePassword: "{{ certs_jks_store_password }}"
+  monitor.ssl.trustStore: "{{ certs_dir }}/{{ certs_jks_file }}"
+  monitor.ssl.trustStorePassword: "{{ certs_jks_store_password }}"
+  monitor.ssl.trustStoreType: JKS
+  rpc.sasl.qop: auth-conf

--- a/roles/accumulo/defaults/main.yaml
+++ b/roles/accumulo/defaults/main.yaml
@@ -1,5 +1,5 @@
-ambari_component_name: accumulo-site
-ambari_component_props:
+accumulo_config_type: accumulo-site
+accumulo_config_props:
   monitor.ssl.keyStore: "{{ certs_dir }}/{{ certs_jks_file }}"
   monitor.ssl.keyStoreType: JKS
   monitor.ssl.keyStorePassword: "{{ certs_jks_store_password }}"

--- a/roles/accumulo/meta/main.yaml
+++ b/roles/accumulo/meta/main.yaml
@@ -1,4 +1,3 @@
 dependencies:
   - certs_common
   - security_common
-  - ambari_config

--- a/roles/accumulo/meta/main.yaml
+++ b/roles/accumulo/meta/main.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - certs_common
+  - ambari_config

--- a/roles/accumulo/meta/main.yaml
+++ b/roles/accumulo/meta/main.yaml
@@ -1,3 +1,4 @@
 dependencies:
   - certs_common
+  - security_common
   - ambari_config

--- a/roles/accumulo/tasks/main.yaml
+++ b/roles/accumulo/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Invoke Ambari config role, to save configs for Accumulo
+  import_role:
+    name: ambari_config
+  vars:
+    ambari_component_section_name: "{{ accumulo_config_type }}"
+    ambari_component_props: "{{ accumulo_config_props }}"

--- a/roles/ambari_config/tasks/main.yaml
+++ b/roles/ambari_config/tasks/main.yaml
@@ -1,16 +1,24 @@
-# TODO: make property update idempotent
 - name: update ambari property for {{ ambari_component_name }}
   delegate_to: '{{ ambari_host }}'
   run_once: true
-  command: >
-    /var/lib/ambari-server/resources/scripts/configs.py
-      -a set
-      -l localhost
-      -n {{ ambari_cluster_name }}
-      -c {{ ambari_component_name }}
-      -k {{ item.key }}
-      -v {{ item.value }}
-  with_dict: '{{ ambari_component_props }}'
+  ambari_cluster_config:
+    protocol: http
+    host: localhost
+    port: 8080
+    username: admin
+    password: admin
+    cluster_name: "{{ ambari_cluster_name }}"
+    config_type: "{{ ambari_component_name }}"
+    ignore_secret: true
+    timeout_sec: 10
+    config_map: |
+       {% set local_dict = {}  %}
+       {% for k in ambari_component_props %}
+       {% set ret = local_dict.update( {k: {'value': ambari_component_props[k] } } ) %}
+       {% endfor %}
+       {{ local_dict|to_json }}
+
+
 
 - name : restart stale components if needed
   delegate_to: localhost

--- a/roles/ambari_config/tasks/main.yaml
+++ b/roles/ambari_config/tasks/main.yaml
@@ -1,14 +1,14 @@
-- name: update ambari property for {{ ambari_component_name }}
-  delegate_to: '{{ ambari_host }}'
+- name: update ambari property for {{ ambari_component_section_name }}
+  delegate_to: localhost
   run_once: true
   ambari_cluster_config:
     protocol: http
-    host: localhost
+    host: "{{ ambari_host }}"
     port: 8080
     username: admin
     password: admin
     cluster_name: "{{ ambari_cluster_name }}"
-    config_type: "{{ ambari_component_name }}"
+    config_type: "{{ ambari_component_section_name }}"
     ignore_secret: true
     timeout_sec: 10
     config_map: |

--- a/roles/kafka/defaults/main.yaml
+++ b/roles/kafka/defaults/main.yaml
@@ -1,5 +1,5 @@
-ambari_component_name: kafka-broker
-ambari_component_props:
+kafka_config_type: kafka-broker
+kafka_config_props:
   listeners: PLAINTEXT://localhost:6667,SSL://localhost:6666
   ssl.key.password: "{{ certs_jks_key_password }}"
   ssl.keystore.location: "{{ certs_dir }}/{{ certs_jks_file }}"

--- a/roles/kafka/defaults/main.yaml
+++ b/roles/kafka/defaults/main.yaml
@@ -1,0 +1,10 @@
+ambari_component_name: kafka-broker
+ambari_component_props:
+  listeners: PLAINTEXT://localhost:6667,SSL://localhost:6666
+  ssl.key.password: "{{ certs_jks_key_password }}"
+  ssl.keystore.location: "{{ certs_dir }}/{{ certs_jks_file }}"
+  ssl.keystore.password: "{{ certs_jks_store_password }}"
+  ssl.keystore.type: JKS
+  ssl.truststore.location: "{{ certs_dir }}/{{ certs_jks_file }}"
+  ssl.truststore.password: "{{ certs_jks_store_password }}"
+  ssl.truststore.type: JKS

--- a/roles/kafka/meta/main.yaml
+++ b/roles/kafka/meta/main.yaml
@@ -2,4 +2,3 @@
 dependencies:
   - certs_common
   - security_common
-  - ambari_config

--- a/roles/kafka/meta/main.yaml
+++ b/roles/kafka/meta/main.yaml
@@ -1,4 +1,5 @@
 ---
 dependencies:
   - certs_common
+  - security_common
   - ambari_config

--- a/roles/kafka/meta/main.yaml
+++ b/roles/kafka/meta/main.yaml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - certs_common
+  - ambari_config

--- a/roles/kafka/tasks/main.yaml
+++ b/roles/kafka/tasks/main.yaml
@@ -1,0 +1,7 @@
+---
+- name: Invoke Ambari config role, to save configs for Kafka
+  import_role:
+    name: ambari_config
+  vars:
+    ambari_component_section_name: "{{ kafka_config_type }}"
+    ambari_component_props: "{{ kafka_config_props }}"

--- a/roles/nifi/defaults/main.yaml
+++ b/roles/nifi/defaults/main.yaml
@@ -15,5 +15,5 @@ additional_elements: # these elements should only be included if ranger is disab
   content: "{{ node_identity_rendered }}"
 
 # these dicts / variables are used by `include_role: 'ambari_config'`. Ansible was never looking for the node_identity.xml.j2 in the current role's templates dir, eg.: `ansible-wire-encryption/roles/nifi/templates` had to use inline jinja2
-ambari_component_name: nifi-ambari-ssl-config
-ambari_component_props: "{{ ranger_plugin.nifi.enabled | ternary(nifi_security_properties, nifi_security_properties | combine(additional_elements)) }}"
+nifi_config_type: nifi-ambari-ssl-config
+nifi_config_props: "{{ ranger_plugin.nifi.enabled | ternary(nifi_security_properties, nifi_security_properties | combine(additional_elements)) }}"

--- a/roles/nifi/defaults/main.yaml
+++ b/roles/nifi/defaults/main.yaml
@@ -7,15 +7,13 @@ nifi_security_properties:
   nifi.security.truststore: "{{ certs_dir }}/{{ certs_jks_file }}"
   nifi.security.truststorePasswd: "{{ certs_jks_key_password }}"
   nifi.security.truststoreType: JKS
-ranger:
-  enabled: "{{ ambari_component_facts['ranger-nifi-plugin-properties']['ranger-nifi-plugin-enabled']|bool }}"
-  additional_elements: # these elements should only be included if ranger is disabled
-    nifi.initial.admin.identity: hrt_qa@HDF.COM
-    # we cannot user template lookup like this:
-    # content: "{{ lookup('template', 'node_identity.xml.j2')|quote }}"
-    # only inline jinja2 (coming from vars/)
-    content: "{{ node_identity_rendered|quote }}"
+additional_elements: # these elements should only be included if ranger is disabled
+  nifi.initial.admin.identity: hrt_qa@HDF.COM
+  # we cannot user template lookup like this:
+  # content: "{{ lookup('template', 'node_identity.xml.j2')|quote }}"
+  # only inline jinja2 (see: 'vars/' folder)
+  content: "{{ node_identity_rendered }}"
 
 # these dicts / variables are used by `include_role: 'ambari_config'`. Ansible was never looking for the node_identity.xml.j2 in the current role's templates dir, eg.: `ansible-wire-encryption/roles/nifi/templates` had to use inline jinja2
 ambari_component_name: nifi-ambari-ssl-config
-ambari_component_props: "{{ ranger.enabled | ternary(nifi_security_properties, nifi_security_properties | combine(ranger.additional_elements)) }}"
+ambari_component_props: "{{ ranger_plugin.nifi.enabled | ternary(nifi_security_properties, nifi_security_properties | combine(additional_elements)) }}"

--- a/roles/nifi/defaults/main.yaml
+++ b/roles/nifi/defaults/main.yaml
@@ -1,6 +1,6 @@
 nifi_security_properties:
   nifi.node.ssl.isenabled: true
-  nifi.security.needClientAuth: False
+  nifi.security.needClientAuth: false
   nifi.security.keystore: "{{ certs_dir }}/{{ certs_jks_file }}"
   nifi.security.keystorePasswd: "{{ certs_jks_key_password }}"
   nifi.security.keystoreType: JKS

--- a/roles/nifi/defaults/main.yaml
+++ b/roles/nifi/defaults/main.yaml
@@ -1,0 +1,21 @@
+nifi_security_properties:
+  nifi.node.ssl.isenabled: true
+  nifi.security.needClientAuth: False
+  nifi.security.keystore: "{{ certs_dir }}/{{ certs_jks_file }}"
+  nifi.security.keystorePasswd: "{{ certs_jks_key_password }}"
+  nifi.security.keystoreType: JKS
+  nifi.security.truststore: "{{ certs_dir }}/{{ certs_jks_file }}"
+  nifi.security.truststorePasswd: "{{ certs_jks_key_password }}"
+  nifi.security.truststoreType: JKS
+ranger:
+  enabled: "{{ ambari_component_facts['ranger-nifi-plugin-properties']['ranger-nifi-plugin-enabled']|bool }}"
+  additional_elements: # these elements should only be included if ranger is disabled
+    nifi.initial.admin.identity: hrt_qa@HDF.COM
+    # we cannot user template lookup like this:
+    # content: "{{ lookup('template', 'node_identity.xml.j2')|quote }}"
+    # only inline jinja2 (coming from vars/)
+    content: "{{ node_identity_rendered|quote }}"
+
+# these dicts / variables are used by `include_role: 'ambari_config'`. Ansible was never looking for the node_identity.xml.j2 in the current role's templates dir, eg.: `ansible-wire-encryption/roles/nifi/templates` had to use inline jinja2
+ambari_component_name: nifi-ambari-ssl-config
+ambari_component_props: "{{ ranger.enabled | ternary(nifi_security_properties, nifi_security_properties | combine(ranger.additional_elements)) }}"

--- a/roles/nifi/meta/main.yaml
+++ b/roles/nifi/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - certs_common

--- a/roles/nifi/meta/main.yaml
+++ b/roles/nifi/meta/main.yaml
@@ -1,2 +1,3 @@
 dependencies:
   - certs_common
+  - security_common

--- a/roles/nifi/tasks/main.yaml
+++ b/roles/nifi/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- name: invoke ambari configuration role to save configurations for NiFi
+  include_role:
+    name: ambari_config

--- a/roles/nifi/tasks/main.yaml
+++ b/roles/nifi/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
-- name: invoke ambari configuration role to save configurations for NiFi
-  include_role:
+- name: Invoke Ambari config role, to save configs for NiFi
+  import_role:
     name: ambari_config
+  vars:
+    ambari_component_section_name: "{{ nifi_config_type }}"
+    ambari_component_props: "{{ nifi_config_props }}"

--- a/roles/nifi/vars/main.yaml
+++ b/roles/nifi/vars/main.yaml
@@ -1,0 +1,14 @@
+node_identity_rendered: |
+          {% set count = namespace(i=1) %}
+          {% for group in groups_to_render %}
+          {% for host in group['cn'] %}
+          <property name="Node Identity {{ count.i }}">CN={{ host }}, OU={{ group['ou'] }}</property>
+          {% set count.i = count.i + 1 %}
+          {% endfor %}
+          {% endfor %}
+
+groups_to_render:
+  - cn: "{{ groups['NIFI_MASTER'] }}"
+    ou: "NIFI"
+#  - cn: "{{ groups['KNOX_GATEWAY'] }}"
+#    ou: "KNOX"

--- a/roles/security_common/defaults/main.yaml
+++ b/roles/security_common/defaults/main.yaml
@@ -1,0 +1,3 @@
+ranger_plugin:
+  nifi:
+    enabled: "{{ ambari_component_facts['ranger-nifi-plugin-properties']['ranger-nifi-plugin-enabled']|bool }}"


### PR DESCRIPTION
it proved to be idempotent as on the second run, it gave back:
```
TASK [ambari_config : update ambari property for nifi-ambari-ssl-config] ***************************************************************************************************************************************************************************************************
ok: [localhost -> 172.27.16.7] => {
    "changed": false, 
    "results": ""
}

MSG:

{u'result': {u'nifi.initial.admin.identity': u'hrt_qa@HDF.COM', u'nifi.security.keystore': u'/etc/wire_encryption/certs.jks', u'nifi.security.truststore': u'/etc/wire_encryption/certs.jks', u'nifi.toolkit.tls.helper.days': u'1095', u'nifi.toolkit.tls.regenerate': u'false', u'nifi.toolkit.dn.prefix': u'CN=', u'nifi.node.ssl.isenabled': u'true', u'content': u'<property name="Node Identity 1">CN=ctr-e138-1518143905142-476678-01-000004.hwx.site, OU=NIFI</property>\n<property name="Node Identity 2">CN=ctr-e138-1518143905142-476678-01-000005.hwx.site, OU=NIFI</property>\n<property name="Node Identity 3">CN=ctr-e138-1518143905142-476678-01-000006.hwx.site, OU=NIFI</property>\n', u'nifi.toolkit.tls.port': u'10443', u'nifi.security.keyPasswd': u'SECRET:nifi-ambari-ssl-config:18:nifi.security.keyPasswd', u'nifi.toolkit.dn.suffix': u', OU=NIFI', u'nifi.security.truststorePasswd': u'changeit', u'nifi.security.needClientAuth': u'false', u'nifi.toolkit.tls.token': u'SECRET:nifi-ambari-ssl-config:18:nifi.toolkit.tls.token', u'nifi.security.keystorePasswd': u'changeit', u'nifi.security.truststoreType': u'JKS', u'nifi.security.keystoreType': u'JKS'}, u'updates': {}}
```